### PR TITLE
Fixed ngrok persistence support PR

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Ngrok::Tunnel.start(addr: 'foo.dev:80',
                     log: 'ngrok.log',
                     config: '~/.ngrok',
                     persistence: true,
-                    persistence_file: '/tmp/ngrok-process') # optional parameter
+                    persistence_file: '/Users/user/.ngrok2/ngrok-process.json') # optional parameter
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,9 @@ Ngrok::Tunnel.start(addr: 'foo.dev:80',
                     authtoken: 'MY_TOKEN',
                     inspect: false,
                     log: 'ngrok.log',
-                    config: '~/.ngrok')
+                    config: '~/.ngrok',
+                    persistence: true,
+                    persistence_file: '/tmp/ngrok-process') # optional parameter
 
 ```
 

--- a/lib/ngrok/tunnel.rb
+++ b/lib/ngrok/tunnel.rb
@@ -103,7 +103,7 @@ module Ngrok
       end
 
       def try_params_from_running_ngrok
-        @persistence_file = @params[:persistence_file] || '/tmp/ngrok-process'
+        @persistence_file = @params[:persistence_file] || "#{File.dirname(@params[:config])}/ngrok-process.json"
         state = parse_persistence_file
         pid = state&.[]('pid')
         raise_if_similar_ngroks(pid)
@@ -143,9 +143,7 @@ module Ngrok
 
       def store_new_ngrok_process
         # Record the attributes of the new process so that it can be reused on a subsequent call.
-        File.open(@persistence_file, 'w') do |f|
-          f.write({ pid: @pid, ngrok_url: @ngrok_url, ngrok_url_https: @ngrok_url_https }.to_json)
-        end
+        File.write(@persistence_file, { pid: @pid, ngrok_url: @ngrok_url, ngrok_url_https: @ngrok_url_https }.to_json)
       end
 
       def ngrok_exec_params

--- a/lib/ngrok/tunnel.rb
+++ b/lib/ngrok/tunnel.rb
@@ -88,7 +88,7 @@ module Ngrok
       def raise_if_similar_ngroks(pid)
         other_similar_ngroks = ngrok_process_status_lines.select do |line|
           # If the pid is not nil and the line starts with this pid, do not take this line into account
-          !(pid && line.start_with?(pid)) && line.include?('ngrok http') && line.end_with?(addr)
+          !(pid && line.start_with?(pid)) && line.include?('ngrok http') && line.end_with?("#{addr}")
         end
 
         return if other_similar_ngroks.empty?
@@ -157,7 +157,7 @@ module Ngrok
         exec_params << "-subdomain=#{@params[:subdomain]} " if @params[:subdomain]
         exec_params << "-hostname=#{@params[:hostname]} " if @params[:hostname]
         exec_params << "-inspect=#{@params[:inspect]} " if @params.has_key? :inspect
-        exec_params << "-config=#{@params[:config]} #{@params[:addr]} > #{@params[:log].path}"
+        exec_params << "-config #{@params[:config]} #{@params[:addr]} > #{@params[:log].path}"
       end
 
       def fetch_urls

--- a/lib/ngrok/tunnel.rb
+++ b/lib/ngrok/tunnel.rb
@@ -24,7 +24,7 @@ module Ngrok
         ensure_binary
         init(params)
 
-        persistent_ngrok = @params[:persistence]
+        persistent_ngrok = @params[:persistence] == true
         # Attempt to read the attributes of an existing process instead of starting a new process.
         try_params_from_running_ngrok if persistent_ngrok
 


### PR DESCRIPTION
This is a second stab at enabling ngrok persistence support, based on the #11 by @scottmartinnet

Is now correctly working, launching ngrok as a background process if persistence key is present.
